### PR TITLE
feat(lexer): add support for two-character tokens

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -1,6 +1,10 @@
 package lexer
 
-import "github.com/freddiehaddad/corrosion/pkg/token"
+import (
+	"strings"
+
+	"github.com/freddiehaddad/corrosion/pkg/token"
+)
 
 type Lexer struct {
 	input        string
@@ -13,55 +17,101 @@ func New(input string) *Lexer {
 	return &Lexer{input: input}
 }
 
-func newToken(tokenType token.TokenType, ch byte) token.Token {
+func newTokenByte(tokenType token.TokenType, ch byte) token.Token {
 	return token.Token{Type: tokenType, Literal: string(ch)}
+}
+
+func newTokenString(tokenType token.TokenType, literal string) token.Token {
+	return token.Token{Type: tokenType, Literal: literal}
 }
 
 func (l *Lexer) NextToken() token.Token {
 	var tok token.Token
+	var sb strings.Builder
 
 	l.readCharacter()
 	switch l.ch {
 	// delimiters
 	case ';':
-		tok = newToken(token.SEMICOLON, l.ch)
+		tok = newTokenByte(token.SEMICOLON, l.ch)
 	case ',':
-		tok = newToken(token.COMMA, l.ch)
+		tok = newTokenByte(token.COMMA, l.ch)
 	case '(':
-		tok = newToken(token.LPAREN, l.ch)
+		tok = newTokenByte(token.LPAREN, l.ch)
 	case ')':
-		tok = newToken(token.RPAREN, l.ch)
+		tok = newTokenByte(token.RPAREN, l.ch)
 	case '[':
-		tok = newToken(token.LBRACKET, l.ch)
+		tok = newTokenByte(token.LBRACKET, l.ch)
 	case ']':
-		tok = newToken(token.RBRACKET, l.ch)
+		tok = newTokenByte(token.RBRACKET, l.ch)
 	case '{':
-		tok = newToken(token.LBRACE, l.ch)
+		tok = newTokenByte(token.LBRACE, l.ch)
 	case '}':
-		tok = newToken(token.RBRACE, l.ch)
+		tok = newTokenByte(token.RBRACE, l.ch)
+
 	// operators
-	case '=':
-		tok = newToken(token.ASSIGN, l.ch)
 	case '+':
-		tok = newToken(token.PLUS, l.ch)
+		tok = newTokenByte(token.PLUS, l.ch)
 	case '-':
-		tok = newToken(token.MINUS, l.ch)
+		tok = newTokenByte(token.MINUS, l.ch)
 	case '*':
-		tok = newToken(token.ASTERISK, l.ch)
+		tok = newTokenByte(token.ASTERISK, l.ch)
 	case '/':
-		tok = newToken(token.FSLASH, l.ch)
+		tok = newTokenByte(token.FSLASH, l.ch)
 	case '<':
-		tok = newToken(token.LESS_THAN, l.ch)
+		tok = newTokenByte(token.LESS_THAN, l.ch)
 	case '>':
-		tok = newToken(token.GREATER_THAN, l.ch)
+		tok = newTokenByte(token.GREATER_THAN, l.ch)
+	case '^':
+		tok = newTokenByte(token.BITWISE_XOR, l.ch)
+	case '~':
+		tok = newTokenByte(token.BITWISE_NOT, l.ch)
+
+	// extended operators
+	case '=':
+		sb.WriteByte(l.ch)
+		if l.peekCharacter() == '=' {
+			l.readCharacter()
+			sb.WriteByte(l.ch)
+			tok = newTokenString(token.EQUAL, sb.String())
+		} else {
+			tok = newTokenByte(token.ASSIGN, l.ch)
+		}
+	case '!':
+		sb.WriteByte(l.ch)
+		if l.peekCharacter() == '=' {
+			l.readCharacter()
+			sb.WriteByte(l.ch)
+			tok = newTokenString(token.NOT_EQUAL, sb.String())
+		} else {
+			tok = newTokenByte(token.BANG, l.ch)
+		}
+	case '&':
+		sb.WriteByte(l.ch)
+		if l.peekCharacter() == '&' {
+			l.readCharacter()
+			sb.WriteByte(l.ch)
+			tok = newTokenString(token.AND, sb.String())
+		} else {
+			tok = newTokenByte(token.BITWISE_AND, l.ch)
+		}
+	case '|':
+		sb.WriteByte(l.ch)
+		if l.peekCharacter() == '|' {
+			l.readCharacter()
+			sb.WriteByte(l.ch)
+			tok = newTokenString(token.OR, sb.String())
+		} else {
+			tok = newTokenByte(token.BITWISE_OR, l.ch)
+		}
 
 	// end of input
 	case token.EOF_VALUE:
-		tok = newToken(token.EOF, l.ch)
+		tok = newTokenByte(token.EOF, l.ch)
 
 	// errors
 	default:
-		tok = newToken(token.UNKNOWN, l.ch)
+		tok = newTokenByte(token.UNKNOWN, l.ch)
 	}
 
 	return tok

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -139,8 +139,21 @@ func TestUnknownInput(t *testing.T) {
 
 }
 
+func TestMultiDigitTokens(t *testing.T) {
+	input := `==!=&&||`
+	tests := []token.Token{
+		{Type: token.EQUAL, Literal: token.EQUAL},
+		{Type: token.NOT_EQUAL, Literal: token.NOT_EQUAL},
+		{Type: token.AND, Literal: token.AND},
+		{Type: token.OR, Literal: token.OR},
+	}
+
+	l := New(input)
+	compareTokens(t, l, tests)
+}
+
 func TestSingleCharaterTokens(t *testing.T) {
-	input := `;,()[]{}=+-*/<>`
+	input := `;,()[]{}=+-*/<>&|^~!`
 	tests := []token.Token{
 		{Type: token.SEMICOLON, Literal: token.SEMICOLON},
 		{Type: token.COMMA, Literal: token.COMMA},
@@ -157,6 +170,11 @@ func TestSingleCharaterTokens(t *testing.T) {
 		{Type: token.FSLASH, Literal: token.FSLASH},
 		{Type: token.LESS_THAN, Literal: token.LESS_THAN},
 		{Type: token.GREATER_THAN, Literal: token.GREATER_THAN},
+		{Type: token.BITWISE_AND, Literal: token.BITWISE_AND},
+		{Type: token.BITWISE_OR, Literal: token.BITWISE_OR},
+		{Type: token.BITWISE_XOR, Literal: token.BITWISE_XOR},
+		{Type: token.BITWISE_NOT, Literal: token.BITWISE_NOT},
+		{Type: token.BANG, Literal: token.BANG},
 		{Type: token.EOF, Literal: string(token.EOF_VALUE)},
 	}
 	l := New(input)

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -22,6 +22,11 @@ const (
 	RBRACE    = "}"
 
 	// operators
+	BITWISE_AND  = "&"
+	BITWISE_OR   = "|"
+	BITWISE_XOR  = "^"
+	BITWISE_NOT  = "~"
+	BANG         = "!"
 	ASSIGN       = "="
 	PLUS         = "+"
 	MINUS        = "-"


### PR DESCRIPTION
Two-character tokens are those such as (&&, ||, !=, and ==).  Bitwise
operators were also added (&, |, ^, ~) as some overlap.
