### PR TITLE
feat(parser): Initial parser support

### DIFF
--- a/cmd/corrosion/corrosion.go
+++ b/cmd/corrosion/corrosion.go
@@ -5,12 +5,40 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/freddiehaddad/corrosion/pkg/ast"
 	"github.com/freddiehaddad/corrosion/pkg/lexer"
-	"github.com/freddiehaddad/corrosion/pkg/token"
+	"github.com/freddiehaddad/corrosion/pkg/parser"
 )
 
 const appName = "Corrosion"
 const prompt = "> "
+
+func evaluate(p *ast.Program) {
+	for index, statement := range p.Statements {
+		fmt.Printf("Statements[%d]: %s\n", index, statement.TokenLiteral())
+	}
+}
+
+func checkProgram(p *ast.Program) bool {
+	if p != nil {
+		return true
+	}
+
+	fmt.Printf("ParseProgram returned nil\n")
+	return false
+}
+
+func checkErrors(p *parser.Parser) {
+	errors := p.Errors()
+	if len(errors) == 0 {
+		return
+	}
+
+	fmt.Printf("ParseProgram returned %d errors\n", len(errors))
+	for index, error := range errors {
+		fmt.Printf("errors[%d]: %s\n", index, error)
+	}
+}
 
 func main() {
 	fmt.Println("Welcome to", appName)
@@ -23,8 +51,13 @@ func main() {
 		input := scanner.Text()
 
 		l := lexer.New(input)
-		for tok := l.NextToken(); tok.Type != token.EOF; tok = l.NextToken() {
-			fmt.Printf("%+v\n", tok)
+		p := parser.New(l)
+		program := p.ParseProgram()
+
+		checkErrors(p)
+
+		if checkProgram(program) {
+			evaluate(program)
 		}
 
 		fmt.Print(prompt)

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -1,0 +1,60 @@
+package ast
+
+import "github.com/freddiehaddad/corrosion/pkg/token"
+
+type Node interface {
+	TokenLiteral() string
+}
+
+type Statement interface {
+	Node
+	statementNode()
+}
+
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+type Program struct {
+	Statements []Statement
+}
+
+func (p *Program) TokenLiteral() string {
+	if len(p.Statements) > 0 {
+		return p.Statements[0].TokenLiteral()
+	} else {
+		return ""
+	}
+}
+
+type DeclarationStatement struct {
+	Value Expression
+	Name  *Identifier
+	Token token.Token
+}
+
+func (ds *DeclarationStatement) statementNode() {}
+func (ds *DeclarationStatement) TokenLiteral() string {
+	return ds.Token.Literal
+}
+
+type Identifier struct {
+	Token token.Token
+	Value string
+}
+
+func (i *Identifier) expressionNode() {}
+func (i *Identifier) TokenLiteral() string {
+	return i.Token.Literal
+}
+
+type IntegerLiteral struct {
+	Token token.Token
+	Value string
+}
+
+func (i *IntegerLiteral) expressionNode() {}
+func (i *IntegerLiteral) TokenLiteral() string {
+	return i.Token.Literal
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,0 +1,135 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/freddiehaddad/corrosion/pkg/ast"
+	"github.com/freddiehaddad/corrosion/pkg/lexer"
+	"github.com/freddiehaddad/corrosion/pkg/token"
+)
+
+type Parser struct {
+	l            *lexer.Lexer
+	currentToken token.Token
+	peekToken    token.Token
+	errors       []string
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{l: l, errors: []string{}}
+	p.nextToken()
+	p.nextToken()
+	return p
+}
+
+func (p *Parser) ParseProgram() *ast.Program {
+	program := &ast.Program{}
+
+	for !p.eof() {
+		switch p.currentToken.Type {
+		case token.INT:
+			if stmt := p.parseStatement(); stmt != nil {
+				program.Statements = append(program.Statements, stmt)
+			}
+		default:
+			msg := fmt.Sprintf("ParseProgram: unexpected token=%s encountered", p.currentToken.Type)
+			p.error(msg)
+		}
+		p.nextToken()
+	}
+	return program
+}
+
+// ----------------------------------------------------------------------------
+// Token functions
+// ----------------------------------------------------------------------------
+
+func (p *Parser) eof() bool {
+	return p.currentTokenIs(token.EOF)
+}
+
+func (p *Parser) expectPeek(t token.TokenType) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	}
+
+	p.peekError(t)
+	return false
+}
+
+func (p *Parser) currentTokenIs(t token.TokenType) bool {
+	return p.currentToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.TokenType) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) peekError(t token.TokenType) {
+	msg := fmt.Sprintf("peekToken=%s expected=%s", p.peekToken.Type, t)
+	p.error(msg)
+}
+
+func (p *Parser) nextToken() {
+	p.currentToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+// ----------------------------------------------------------------------------
+// Error functions
+// ----------------------------------------------------------------------------
+
+func (p *Parser) Errors() []string {
+	return p.errors
+}
+
+func (p *Parser) error(msg string) {
+	p.errors = append(p.errors, msg)
+}
+
+// ----------------------------------------------------------------------------
+// Parsing functions
+// ----------------------------------------------------------------------------
+
+func (p *Parser) parseStatement() ast.Statement {
+	decType := p.currentToken // int
+
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+
+	switch p.peekToken.Type {
+	case token.ASSIGN:
+		return p.parseDeclarationStatement(decType)
+	default:
+		p.error(fmt.Sprintf("unexpected peekToken=%s", p.peekToken.Type))
+		return nil
+	}
+}
+
+func (p *Parser) parseDeclarationStatement(decType token.Token) ast.Statement {
+	ds := &ast.DeclarationStatement{Token: decType}
+
+	ds.Name = p.parseIdentifier()
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	// TODO: parse the expression.
+	// skip everything up to the semicolon
+	for !p.eof() {
+		if p.currentTokenIs(token.SEMICOLON) {
+			return ds
+		}
+		p.nextToken()
+	}
+
+	p.error(fmt.Sprintf("parseDeclarationStatement: %+v - expected a semicolon after expression", ds))
+	return nil
+}
+
+func (p *Parser) parseIdentifier() *ast.Identifier {
+	return &ast.Identifier{Token: p.currentToken, Value: p.currentToken.Literal}
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,0 +1,86 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/freddiehaddad/corrosion/pkg/ast"
+	"github.com/freddiehaddad/corrosion/pkg/lexer"
+)
+
+type decTest struct {
+	decType string
+	decName string
+}
+
+func checkProgram(t *testing.T, p *ast.Program) {
+	if p == nil {
+		t.Fatalf("ParseProgram returned nil\n")
+	}
+}
+
+func checkErrors(t *testing.T, p *Parser) {
+	errors := p.Errors()
+	if len(errors) == 0 {
+		return
+	}
+
+	t.Errorf("ParseProgram returned %d errors\n", len(errors))
+	for errno, error := range errors {
+		t.Errorf("errors[%d]: %s", errno, error)
+	}
+
+	t.FailNow()
+}
+
+func checkLength(t *testing.T, tests []decTest, stmts []ast.Statement) {
+	if len(stmts) != len(tests) {
+		t.Fatalf("ParseProgram returned %d statements, expected %d\n", len(stmts), len(tests))
+	}
+}
+
+func checkStatements(t *testing.T, tests []decTest, stmts []ast.Statement) {
+	for i, test := range tests {
+		stmt, ok := stmts[i].(*ast.DeclarationStatement)
+		if !ok {
+			t.Errorf("tests[%d]: wrong type. expected=DeclarationStatement got=%T\n", i, stmt)
+			continue
+		}
+
+		checkStatement(t, i, test, stmt)
+	}
+}
+
+func checkStatement(t *testing.T, test int, expected decTest, stmt *ast.DeclarationStatement) {
+	if expected.decType != stmt.TokenLiteral() {
+		t.Errorf("tests[%d]: incorrect type. expected=%q got=%q\n",
+			test, expected.decType, stmt.TokenLiteral())
+	}
+
+	if expected.decName != stmt.Name.Value {
+		t.Errorf("tests[%d]: incorrect identifier. expected=%q got=%q\n",
+			test, expected.decName, stmt.Name.Value)
+	}
+}
+
+func TestDeclarationStatement(t *testing.T) {
+	input := `
+		int x = 0;
+		int y = 10;
+		int bigNumber = 999999;
+		`
+
+	tests := []decTest{
+		{"int", "x"},
+		{"int", "y"},
+		{"int", "bigNumber"},
+	}
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+
+	checkProgram(t, program)
+	checkErrors(t, p)
+	checkLength(t, tests, program.Statements)
+	checkStatements(t, tests, program.Statements)
+}


### PR DESCRIPTION
The first iteration defines the parsing structures and methods for token
advancement plus the partially parsing variable declaration statements.

Further iterations will introduce support for other statement types
such as return statements and function declarations.
