### PR TITLE
feat: Add support for return statements

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -39,6 +39,16 @@ func (ds *DeclarationStatement) TokenLiteral() string {
 	return ds.Token.Literal
 }
 
+type ReturnStatement struct {
+	ReturnValue Expression
+	Token token.Token
+}
+
+func (ds *ReturnStatement) statementNode() {}
+func (ds *ReturnStatement) TokenLiteral() string {
+	return ds.Token.Literal
+}
+
 type Identifier struct {
 	Token token.Token
 	Value string

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -28,12 +28,18 @@ func compareTokens(t *testing.T, l *Lexer, tokens []expectedToken) {
 }
 
 func TestNextToken(t *testing.T) {
-	input := "int x = 10;"
+	input := `
+		int x = 10;
+		return 5;
+		`
 	tests := []expectedToken{
 		{expectedType: token.INT, expectedLiteral: "int"},
 		{expectedType: token.IDENT, expectedLiteral: "x"},
 		{expectedType: token.ASSIGN, expectedLiteral: "="},
 		{expectedType: token.INTEGER, expectedLiteral: "10"},
+		{expectedType: token.SEMICOLON, expectedLiteral: ";"},
+		{expectedType: token.RETURN, expectedLiteral: "return"},
+		{expectedType: token.INTEGER, expectedLiteral: "5"},
 		{expectedType: token.SEMICOLON, expectedLiteral: ";"},
 		{expectedType: token.EOF, expectedLiteral: string(token.EOF_VALUE)},
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 type decTest struct {
-	decType string
-	decName string
+	tokenLiteral string
+	decName      string
 }
 
 func checkProgram(t *testing.T, p *ast.Program) {
@@ -39,26 +39,34 @@ func checkLength(t *testing.T, tests []decTest, stmts []ast.Statement) {
 }
 
 func checkStatements(t *testing.T, tests []decTest, stmts []ast.Statement) {
-	for i, test := range tests {
-		stmt, ok := stmts[i].(*ast.DeclarationStatement)
-		if !ok {
-			t.Errorf("tests[%d]: wrong type. expected=DeclarationStatement got=%T\n", i, stmt)
-			continue
+	for i, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.DeclarationStatement:
+			checkDeclarationStatement(t, i, tests[i], s)
+		case *ast.ReturnStatement:
+			checkReturnStatement(t, i, tests[i], s)
+		default:
+			t.Errorf("tests[%d]: wrong type. got=%T\n", i, stmt)
 		}
-
-		checkStatement(t, i, test, stmt)
 	}
 }
 
-func checkStatement(t *testing.T, test int, expected decTest, stmt *ast.DeclarationStatement) {
-	if expected.decType != stmt.TokenLiteral() {
+func checkDeclarationStatement(t *testing.T, test int, expected decTest, stmt *ast.DeclarationStatement) {
+	if expected.tokenLiteral != stmt.TokenLiteral() {
 		t.Errorf("tests[%d]: incorrect type. expected=%q got=%q\n",
-			test, expected.decType, stmt.TokenLiteral())
+			test, expected.tokenLiteral, stmt.TokenLiteral())
 	}
 
 	if expected.decName != stmt.Name.Value {
 		t.Errorf("tests[%d]: incorrect identifier. expected=%q got=%q\n",
 			test, expected.decName, stmt.Name.Value)
+	}
+}
+
+func checkReturnStatement(t *testing.T, test int, expected decTest, stmt *ast.ReturnStatement) {
+	if expected.tokenLiteral != stmt.TokenLiteral() {
+		t.Errorf("tests[%d]: incorrect type. expected=%q got=%q\n",
+			test, expected.tokenLiteral, stmt.TokenLiteral())
 	}
 }
 
@@ -73,6 +81,27 @@ func TestDeclarationStatement(t *testing.T) {
 		{"int", "x"},
 		{"int", "y"},
 		{"int", "bigNumber"},
+	}
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+
+	checkProgram(t, program)
+	checkErrors(t, p)
+	checkLength(t, tests, program.Statements)
+	checkStatements(t, tests, program.Statements)
+}
+
+func TestReturnStatement(t *testing.T) {
+	input := `
+		return x;
+		return 100;
+		`
+
+	tests := []decTest{
+		{"return", "x"},
+		{"return", "100"},
 	}
 
 	l := lexer.New(input)

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -19,6 +19,7 @@ const (
 
 	// keywords
 	INT = "INT"
+	RETURN = "RETURN"
 
 	// literals
 	IDENT   = "IDENT"
@@ -35,6 +36,7 @@ const (
 // Language keywords.
 var keywords = map[string]TokenType{
 	"int": INT,
+	"return": RETURN,
 }
 
 // Checks if tt is in the keyword table and return the corresponding TokenType.


### PR DESCRIPTION
Scope of changes include:

    - ast
    - lexer
    - lexer tests
    - parser
    - parser tests

Support for lexing and parsing return statements was added in this
commit. Expressions are still being skipped.
