### PR TITLE
feat: Add a String() method to AST nodes

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -1,9 +1,14 @@
 package ast
 
-import "github.com/freddiehaddad/corrosion/pkg/token"
+import (
+	"strings"
+
+	"github.com/freddiehaddad/corrosion/pkg/token"
+)
 
 type Node interface {
 	TokenLiteral() string
+	String() string
 }
 
 type Statement interface {
@@ -23,10 +28,24 @@ type Program struct {
 func (p *Program) TokenLiteral() string {
 	if len(p.Statements) > 0 {
 		return p.Statements[0].TokenLiteral()
-	} else {
-		return ""
 	}
+
+	return ""
 }
+
+func (p *Program) String() string {
+	sb := strings.Builder{}
+
+	for _, s := range p.Statements {
+		sb.WriteString(s.String())
+	}
+
+	return sb.String()
+}
+
+// ----------------------------------------------------------------------------
+// Statement types
+// ----------------------------------------------------------------------------
 
 type DeclarationStatement struct {
 	Value Expression
@@ -38,16 +57,56 @@ func (ds *DeclarationStatement) statementNode() {}
 func (ds *DeclarationStatement) TokenLiteral() string {
 	return ds.Token.Literal
 }
+func (ds *DeclarationStatement) String() string {
+	sb := strings.Builder{}
+	sb.WriteString(ds.TokenLiteral())
+	sb.WriteString(" ")
+	sb.WriteString(ds.Name.String())
+	sb.WriteString(" = ")
+	if ds.Value != nil {
+		sb.WriteString(ds.Value.String())
+	}
+	sb.WriteString(";")
+	return sb.String()
+}
+
+type ExpressionStatement struct {
+	Expression Expression
+	Token      token.Token
+}
+
+func (es *ExpressionStatement) statementNode()       {}
+func (es *ExpressionStatement) TokenLiteral() string { return es.Token.Literal }
+func (es *ExpressionStatement) String() string {
+	if es.Expression != nil {
+		return es.Expression.String()
+	}
+	return ""
+}
 
 type ReturnStatement struct {
 	ReturnValue Expression
-	Token token.Token
+	Token       token.Token
 }
 
-func (ds *ReturnStatement) statementNode() {}
-func (ds *ReturnStatement) TokenLiteral() string {
-	return ds.Token.Literal
+func (rs *ReturnStatement) statementNode() {}
+func (rs *ReturnStatement) TokenLiteral() string {
+	return rs.Token.Literal
 }
+func (rs *ReturnStatement) String() string {
+	sb := strings.Builder{}
+	sb.WriteString(rs.TokenLiteral())
+	sb.WriteString(" ")
+	if rs.ReturnValue != nil {
+		sb.WriteString(rs.ReturnValue.String())
+	}
+	sb.WriteString(";")
+	return sb.String()
+}
+
+// ----------------------------------------------------------------------------
+// Basic types
+// ----------------------------------------------------------------------------
 
 type Identifier struct {
 	Token token.Token
@@ -58,6 +117,9 @@ func (i *Identifier) expressionNode() {}
 func (i *Identifier) TokenLiteral() string {
 	return i.Token.Literal
 }
+func (i *Identifier) String() string {
+	return i.Value
+}
 
 type IntegerLiteral struct {
 	Token token.Token
@@ -67,4 +129,7 @@ type IntegerLiteral struct {
 func (i *IntegerLiteral) expressionNode() {}
 func (i *IntegerLiteral) TokenLiteral() string {
 	return i.Token.Literal
+}
+func (i *IntegerLiteral) String() string {
+	return i.Value
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -124,7 +124,8 @@ func (p *Parser) parseReturnStatement() ast.Statement {
 		p.nextToken()
 	}
 
-	return rs
+	p.error(fmt.Sprintf("parseReturnStatement: %+v - expected a semicolon after expression", rs))
+	return nil
 }
 
 func (p *Parser) parseVariableDeclarationStatement(decType token.Token) ast.Statement {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -113,3 +113,18 @@ func TestReturnStatement(t *testing.T) {
 	checkLength(t, tests, program.Statements)
 	checkStatements(t, tests, program.Statements)
 }
+
+func TestProgramString(t *testing.T) {
+	input := "int x = 5;"
+	expected := "int x = ;"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkProgram(t, program)
+	checkErrors(t, p)
+
+	if program.String() != expected {
+		t.Errorf("program.String() returned %q, expected %q\n", program.String(), expected)
+	}
+}


### PR DESCRIPTION
The String() method will assist in writing tests and debugging advanced
parsing algorithms required for expressions. Rather than trying to test
tree/node structures, instead the string represntation of the AST can be
compared for correctness.
