### PR TITLE
feat: expression parsing of idents and ints

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -49,7 +49,7 @@ func (p *Program) String() string {
 
 type DeclarationStatement struct {
 	Value Expression
-	Name  *Identifier
+	Name  Identifier
 	Token token.Token
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -8,17 +8,34 @@ import (
 	"github.com/freddiehaddad/corrosion/pkg/token"
 )
 
+const (
+	_ int = iota
+	LOWEST
+)
+
+type (
+	prefixParseFn func() ast.Expression
+	infixParseFn  func(ast.Expression) ast.Expression
+)
+
 type Parser struct {
-	l            *lexer.Lexer
-	currentToken token.Token
-	peekToken    token.Token
-	errors       []string
+	l              *lexer.Lexer
+	prefixParseFns map[token.TokenType]prefixParseFn
+	infixParseFns  map[token.TokenType]infixParseFn
+	currentToken   token.Token
+	peekToken      token.Token
+	errors         []string
 }
 
 func New(l *lexer.Lexer) *Parser {
 	p := &Parser{l: l, errors: []string{}}
 	p.nextToken()
 	p.nextToken()
+
+	p.prefixParseFns = make(map[token.TokenType]prefixParseFn)
+	p.registerPrefix(token.IDENT, p.parseIdentifier)
+	p.registerPrefix(token.INTEGER, p.parseInteger)
+
 	return p
 }
 
@@ -26,21 +43,19 @@ func (p *Parser) ParseProgram() *ast.Program {
 	program := &ast.Program{}
 
 	for !p.eof() {
+		var stmt ast.Statement
 		switch p.currentToken.Type {
 		case token.INT:
-			if stmt := p.parseDeclarationStatement(); stmt != nil {
-				program.Statements = append(program.Statements, stmt)
-			}
+			stmt = p.parseDeclarationStatement()
 		case token.RETURN:
-			if stmt := p.parseReturnStatement(); stmt != nil {
-				program.Statements = append(program.Statements, stmt)
-			}
+			stmt = p.parseReturnStatement()
 		default:
-			msg := fmt.Sprintf("ParseProgram: unexpected token=%s encountered", p.currentToken.Type)
-			p.error(msg)
+			stmt = p.parseExpressionStatement()
 		}
+		program.Statements = append(program.Statements, stmt)
 		p.nextToken()
 	}
+
 	return program
 }
 
@@ -81,6 +96,18 @@ func (p *Parser) nextToken() {
 }
 
 // ----------------------------------------------------------------------------
+// Prefix functions
+// ----------------------------------------------------------------------------
+
+func (p *Parser) registerPrefix(tokenType token.TokenType, fn prefixParseFn) {
+	p.prefixParseFns[tokenType] = fn
+}
+
+func (p *Parser) registerInfix(tokenType token.TokenType, fn infixParseFn) {
+	p.infixParseFns[tokenType] = fn
+}
+
+// ----------------------------------------------------------------------------
 // Error functions
 // ----------------------------------------------------------------------------
 
@@ -93,23 +120,25 @@ func (p *Parser) error(msg string) {
 }
 
 // ----------------------------------------------------------------------------
-// Parsing functions
+// Statement parsing functions
 // ----------------------------------------------------------------------------
 
 func (p *Parser) parseDeclarationStatement() ast.Statement {
+	var stmt ast.Statement
 	decType := p.currentToken // int
 
 	if !p.expectPeek(token.IDENT) {
-		return nil
+		return stmt
 	}
 
 	switch p.peekToken.Type {
 	case token.ASSIGN:
-		return p.parseVariableDeclarationStatement(decType)
+		stmt = p.parseVariableDeclarationStatement(decType)
 	default:
 		p.error(fmt.Sprintf("unexpected peekToken=%s", p.peekToken.Type))
-		return nil
 	}
+
+	return stmt
 }
 
 func (p *Parser) parseReturnStatement() ast.Statement {
@@ -129,27 +158,46 @@ func (p *Parser) parseReturnStatement() ast.Statement {
 }
 
 func (p *Parser) parseVariableDeclarationStatement(decType token.Token) ast.Statement {
-	ds := &ast.DeclarationStatement{Token: decType}
+	ds := &ast.DeclarationStatement{Token: decType} // int
 
-	ds.Name = p.parseIdentifier()
+	ds.Name = ast.Identifier{Token: p.currentToken, Value: p.currentToken.Literal} // x
 
 	if !p.expectPeek(token.ASSIGN) {
-		return nil
+		return ds
 	}
+	p.nextToken() // =
 
-	// TODO: parse the expression.
-	// skip everything up to the semicolon
-	for !p.eof() {
-		if p.currentTokenIs(token.SEMICOLON) {
-			return ds
-		}
-		p.nextToken()
-	}
+	ds.Value = p.parseExpression(LOWEST)
 
-	p.error(fmt.Sprintf("parseDeclarationStatement: %+v - expected a semicolon after expression", ds))
-	return nil
+	p.expectPeek(token.SEMICOLON)
+
+	return ds
 }
 
-func (p *Parser) parseIdentifier() *ast.Identifier {
+// ----------------------------------------------------------------------------
+// Expression parsing functions
+// ----------------------------------------------------------------------------
+
+func (p *Parser) parseIdentifier() ast.Expression {
 	return &ast.Identifier{Token: p.currentToken, Value: p.currentToken.Literal}
+}
+
+func (p *Parser) parseInteger() ast.Expression {
+	return &ast.IntegerLiteral{Token: p.currentToken, Value: p.currentToken.Literal}
+}
+
+func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
+	es := &ast.ExpressionStatement{Token: p.currentToken}
+	es.Expression = p.parseExpression(LOWEST)
+	// TODO: peekTokenIs(token.SEMICOLON)?
+	return es
+}
+
+func (p *Parser) parseExpression(precedence int) ast.Expression {
+	prefix := p.prefixParseFns[p.currentToken.Type]
+	if prefix == nil {
+		return nil
+	}
+	leftExp := prefix()
+	return leftExp
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/freddiehaddad/corrosion/pkg/lexer"
 )
 
-type decTest struct {
-	tokenLiteral string
-	decName      string
-}
+type testResults [][]string
+
+// ----------------------------------------------------------------------------
+// Test helper functions
+// ----------------------------------------------------------------------------
 
 func checkProgram(t *testing.T, p *ast.Program) {
 	if p == nil {
@@ -32,56 +33,67 @@ func checkErrors(t *testing.T, p *Parser) {
 	t.FailNow()
 }
 
-func checkLength(t *testing.T, tests []decTest, stmts []ast.Statement) {
-	if len(stmts) != len(tests) {
-		t.Fatalf("ParseProgram returned %d statements, expected %d\n", len(stmts), len(tests))
+func checkLength(t *testing.T, length int, stmts []ast.Statement) {
+	if len(stmts) != length {
+		t.Fatalf("ParseProgram returned %d statements, expected %d\n", len(stmts), length)
 	}
 }
 
-func checkStatements(t *testing.T, tests []decTest, stmts []ast.Statement) {
+func checkStatements(t *testing.T, expects testResults, stmts []ast.Statement) {
 	for i, stmt := range stmts {
 		switch s := stmt.(type) {
 		case *ast.DeclarationStatement:
-			checkDeclarationStatement(t, i, tests[i], s)
+			checkDeclarationStatement(t, i, expects[i], s)
 		case *ast.ReturnStatement:
-			checkReturnStatement(t, i, tests[i], s)
+			checkReturnStatement(t, i, expects[i], s)
 		default:
 			t.Errorf("tests[%d]: wrong type. got=%T\n", i, stmt)
 		}
 	}
 }
 
-func checkDeclarationStatement(t *testing.T, test int, expected decTest, stmt *ast.DeclarationStatement) {
-	if expected.tokenLiteral != stmt.TokenLiteral() {
+func checkDeclarationStatement(t *testing.T, test int, expected []string, stmt *ast.DeclarationStatement) {
+	// int
+	if expected[0] != stmt.TokenLiteral() {
 		t.Errorf("tests[%d]: incorrect type. expected=%q got=%q\n",
-			test, expected.tokenLiteral, stmt.TokenLiteral())
+			test, expected[0], stmt.TokenLiteral())
 	}
 
-	if expected.decName != stmt.Name.Value {
+	// x
+	if expected[1] != stmt.Name.TokenLiteral() {
 		t.Errorf("tests[%d]: incorrect identifier. expected=%q got=%q\n",
-			test, expected.decName, stmt.Name.Value)
+			test, expected[1], stmt.Name.TokenLiteral())
+	}
+
+	// =
+
+	// y
+	if expected[2] != stmt.Value.String() {
+		t.Errorf("tests[%d]: incorrect identifier. expected=%q got=%q\n",
+			test, expected[1], stmt.Name.TokenLiteral())
+	}
+
+	// ;
+}
+
+func checkReturnStatement(t *testing.T, test int, expected []string, stmt *ast.ReturnStatement) {
+	// return
+	if expected[0] != stmt.TokenLiteral() {
+		t.Errorf("tests[%d]: incorrect type. expected=%q got=%q\n",
+			test, expected[0], stmt.TokenLiteral())
 	}
 }
 
-func checkReturnStatement(t *testing.T, test int, expected decTest, stmt *ast.ReturnStatement) {
-	if expected.tokenLiteral != stmt.TokenLiteral() {
-		t.Errorf("tests[%d]: incorrect type. expected=%q got=%q\n",
-			test, expected.tokenLiteral, stmt.TokenLiteral())
-	}
-}
+// ----------------------------------------------------------------------------
+// Statement tests
+// ----------------------------------------------------------------------------
 
 func TestDeclarationStatement(t *testing.T) {
 	input := `
-		int x = 0;
-		int y = 10;
-		int bigNumber = 999999;
-		`
-
-	tests := []decTest{
-		{"int", "x"},
-		{"int", "y"},
-		{"int", "bigNumber"},
-	}
+	int x = 0;
+	int y = x;
+	`
+	expected := testResults{{"int", "x", "0"}, {"int", "y", "x"}}
 
 	l := lexer.New(input)
 	p := New(l)
@@ -89,20 +101,13 @@ func TestDeclarationStatement(t *testing.T) {
 
 	checkProgram(t, program)
 	checkErrors(t, p)
-	checkLength(t, tests, program.Statements)
-	checkStatements(t, tests, program.Statements)
+	checkLength(t, len(expected), program.Statements)
+	checkStatements(t, expected, program.Statements)
 }
 
 func TestReturnStatement(t *testing.T) {
-	input := `
-		return x;
-		return 100;
-		`
-
-	tests := []decTest{
-		{"return", "x"},
-		{"return", "100"},
-	}
+	input := "return x;"
+	expected := testResults{{"return", "x"}}
 
 	l := lexer.New(input)
 	p := New(l)
@@ -110,13 +115,41 @@ func TestReturnStatement(t *testing.T) {
 
 	checkProgram(t, program)
 	checkErrors(t, p)
-	checkLength(t, tests, program.Statements)
-	checkStatements(t, tests, program.Statements)
+	checkLength(t, len(expected), program.Statements)
+	checkStatements(t, expected, program.Statements)
 }
+
+// ----------------------------------------------------------------------------
+// Expression tests
+// ----------------------------------------------------------------------------
+
+func TestIdentifierExpression(t *testing.T) {
+	input := "foobar;"
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+
+	checkProgram(t, program)
+	checkErrors(t, p)
+}
+
+func TestIntegerLiteralExpression(t *testing.T) {
+	input := "5;"
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+
+	checkProgram(t, program)
+	checkErrors(t, p)
+}
+
+// ----------------------------------------------------------------------------
+// Miscellaneous tests
+// ----------------------------------------------------------------------------
 
 func TestProgramString(t *testing.T) {
 	input := "int x = 5;"
-	expected := "int x = ;"
+	expected := "int x = 5;"
 
 	l := lexer.New(input)
 	p := New(l)


### PR DESCRIPTION
The initial Pratt parser has been implemented, tests updated, and
support for parsing integer literals and identifiers in the expression
position is complete.
