### PR TITLE
feat: initial support for prefix operator parsing

### DIFF
--- a/cmd/corrosion/corrosion.go
+++ b/cmd/corrosion/corrosion.go
@@ -15,37 +15,32 @@ const prompt = "> "
 
 func evaluate(p *ast.Program) {
 	for index, statement := range p.Statements {
-		fmt.Printf("Statements[%d]: %s\n", index, statement.TokenLiteral())
+		fmt.Printf("Statements[%d]: %s\n", index, statement.String())
 	}
 }
 
-func checkProgram(p *ast.Program) bool {
-	if p != nil {
-		return true
-	}
-
-	fmt.Printf("ParseProgram returned nil\n")
-	return false
-}
-
-func checkErrors(p *parser.Parser) {
+// Returns true if there were any parser errors.
+func checkAndPrintErrors(p *parser.Parser) bool {
 	errors := p.Errors()
 	if len(errors) == 0 {
-		return
+		return false
 	}
 
 	fmt.Printf("ParseProgram returned %d errors\n", len(errors))
 	for index, error := range errors {
 		fmt.Printf("errors[%d]: %s\n", index, error)
 	}
+
+	return true
 }
 
 func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+
 	fmt.Println("Welcome to", appName)
 	fmt.Println("")
 	fmt.Println("Press Ctrl+D (^D) to exit")
 
-	scanner := bufio.NewScanner(os.Stdin)
 	fmt.Print(prompt)
 	for scanner.Scan() {
 		input := scanner.Text()
@@ -54,9 +49,7 @@ func main() {
 		p := parser.New(l)
 		program := p.ParseProgram()
 
-		checkErrors(p)
-
-		if checkProgram(program) {
+		if !checkAndPrintErrors(p) {
 			evaluate(program)
 		}
 

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -63,9 +63,7 @@ func (ds *DeclarationStatement) String() string {
 	sb.WriteString(" ")
 	sb.WriteString(ds.Name.String())
 	sb.WriteString(" = ")
-	if ds.Value != nil {
-		sb.WriteString(ds.Value.String())
-	}
+	sb.WriteString(ds.Value.String())
 	sb.WriteString(";")
 	return sb.String()
 }
@@ -77,11 +75,23 @@ type ExpressionStatement struct {
 
 func (es *ExpressionStatement) statementNode()       {}
 func (es *ExpressionStatement) TokenLiteral() string { return es.Token.Literal }
-func (es *ExpressionStatement) String() string {
-	if es.Expression != nil {
-		return es.Expression.String()
-	}
-	return ""
+func (es *ExpressionStatement) String() string       { return es.Expression.String() }
+
+type PrefixExpression struct {
+	Right    Expression
+	Token    token.Token // Prefix operator (e.g. - !)
+	Operator string
+}
+
+func (p *PrefixExpression) expressionNode()      {}
+func (p *PrefixExpression) TokenLiteral() string { return p.Token.Literal }
+func (p *PrefixExpression) String() string {
+	sb := strings.Builder{}
+	sb.WriteByte('(')
+	sb.WriteString(p.Operator)
+	sb.WriteString(p.Right.String())
+	sb.WriteByte(')')
+	return sb.String()
 }
 
 type ReturnStatement struct {
@@ -89,17 +99,13 @@ type ReturnStatement struct {
 	Token       token.Token
 }
 
-func (rs *ReturnStatement) statementNode() {}
-func (rs *ReturnStatement) TokenLiteral() string {
-	return rs.Token.Literal
-}
+func (rs *ReturnStatement) statementNode()       {}
+func (rs *ReturnStatement) TokenLiteral() string { return rs.Token.Literal }
 func (rs *ReturnStatement) String() string {
 	sb := strings.Builder{}
 	sb.WriteString(rs.TokenLiteral())
 	sb.WriteString(" ")
-	if rs.ReturnValue != nil {
-		sb.WriteString(rs.ReturnValue.String())
-	}
+	sb.WriteString(rs.ReturnValue.String())
 	sb.WriteString(";")
 	return sb.String()
 }
@@ -113,23 +119,15 @@ type Identifier struct {
 	Value string
 }
 
-func (i *Identifier) expressionNode() {}
-func (i *Identifier) TokenLiteral() string {
-	return i.Token.Literal
-}
-func (i *Identifier) String() string {
-	return i.Value
-}
+func (i *Identifier) expressionNode()      {}
+func (i *Identifier) TokenLiteral() string { return i.Token.Literal }
+func (i *Identifier) String() string       { return i.Value }
 
 type IntegerLiteral struct {
 	Token token.Token
 	Value string
 }
 
-func (i *IntegerLiteral) expressionNode() {}
-func (i *IntegerLiteral) TokenLiteral() string {
-	return i.Token.Literal
-}
-func (i *IntegerLiteral) String() string {
-	return i.Value
-}
+func (i *IntegerLiteral) expressionNode()      {}
+func (i *IntegerLiteral) TokenLiteral() string { return i.Token.Literal }
+func (i *IntegerLiteral) String() string       { return i.Value }

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -52,6 +52,8 @@ func (l *Lexer) generateTokens() {
 		// operators
 		case '=':
 			tok = newTokenByte(token.ASSIGN, l.ch)
+		case '-':
+			tok = newTokenByte(token.MINUS, l.ch)
 
 		default:
 			if isAlpha(l.ch) {

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -30,7 +30,7 @@ func compareTokens(t *testing.T, l *Lexer, tokens []expectedToken) {
 func TestNextToken(t *testing.T) {
 	input := `
 		int x = 10;
-		return 5;
+		return -5;
 		`
 	tests := []expectedToken{
 		{expectedType: token.INT, expectedLiteral: "int"},
@@ -39,6 +39,7 @@ func TestNextToken(t *testing.T) {
 		{expectedType: token.INTEGER, expectedLiteral: "10"},
 		{expectedType: token.SEMICOLON, expectedLiteral: ";"},
 		{expectedType: token.RETURN, expectedLiteral: "return"},
+		{expectedType: token.MINUS, expectedLiteral: "-"},
 		{expectedType: token.INTEGER, expectedLiteral: "5"},
 		{expectedType: token.SEMICOLON, expectedLiteral: ";"},
 		{expectedType: token.EOF, expectedLiteral: string(token.EOF_VALUE)},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -54,28 +54,42 @@ func checkStatements(t *testing.T, expects testResults, stmts []ast.Statement) {
 	}
 }
 
-func checkIdentifier(t *testing.T, test int, expected []string, stmt *ast.Identifier) {
-	if stmt.Value != expected[0] {
+func checkIdentifier(t *testing.T, test int, expected []string, node *ast.Identifier) {
+	if node.Value != expected[0] {
 		t.Errorf("tests[%d]: incorrect value. expected=%q got=%q\n",
-			test, expected[0], stmt.Value)
+			test, expected[0], node.Value)
 	}
 }
 
-func checkIntegerLiteral(t *testing.T, test int, expected []string, stmt *ast.IntegerLiteral) {
-	if stmt.Value != expected[0] {
+func checkIntegerLiteral(t *testing.T, test int, expected []string, node *ast.IntegerLiteral) {
+	if node.Value != expected[0] {
 		t.Errorf("tests[%d]: incorrect value. expected=%q got=%q\n",
-			test, expected[0], stmt.Value)
+			test, expected[0], node.Value)
 	}
 }
 
-func checkExpressionStatement(t *testing.T, test int, expected []string, stmt *ast.ExpressionStatement) {
-	switch s := stmt.Expression.(type) {
+func checkPrefixExpression(t *testing.T, test int, expected []string, node *ast.PrefixExpression) {
+	if node.Operator != expected[0] {
+		t.Errorf("tests[%d]: incorrect operator. expected=%q got=%q\n",
+			test, expected[0], node.Operator)
+	}
+
+	if node.Right.String() != expected[1] {
+		t.Errorf("tests[%d]: incorrect Expression. expected=%q got=%q\n",
+			test, expected[1], node.Right.String())
+	}
+}
+
+func checkExpressionStatement(t *testing.T, test int, expected []string, node *ast.ExpressionStatement) {
+	switch s := node.Expression.(type) {
 	case *ast.Identifier:
 		checkIdentifier(t, test, expected, s)
 	case *ast.IntegerLiteral:
 		checkIntegerLiteral(t, test, expected, s)
+	case *ast.PrefixExpression:
+		checkPrefixExpression(t, test, expected, s)
 	default:
-		t.Errorf("tests[%d]: wrong type. got=%T\n", test, stmt.Expression)
+		t.Errorf("tests[%d]: wrong type. got=%T\n", test, node.Expression)
 	}
 }
 
@@ -182,6 +196,22 @@ func TestIntegerLiteralExpression(t *testing.T) {
 	checkErrors(t, p)
 	checkLength(t, len(expected), program.Statements)
 	checkStatements(t, expected, program.Statements)
+}
+
+func TestPrefixOperatorExpressions(t *testing.T) {
+	{
+		input := "-10;"
+		expected := testResults{{"-", "10"}}
+
+		l := lexer.New(input)
+		p := New(l)
+		program := p.ParseProgram()
+
+		checkProgram(t, program)
+		checkErrors(t, p)
+		checkLength(t, len(expected), program.Statements)
+		checkStatements(t, expected, program.Statements)
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -12,13 +12,14 @@ type Token struct {
 // Tokens
 const (
 	// delimiters
-	SEMICOLON = "SEMICOLON"
+	SEMICOLON = ";"
 
 	// operators
-	ASSIGN = "ASSIGN"
+	ASSIGN = "="
+	MINUS  = "-"
 
 	// keywords
-	INT = "INT"
+	INT    = "INT"
 	RETURN = "RETURN"
 
 	// literals
@@ -35,7 +36,7 @@ const (
 
 // Language keywords.
 var keywords = map[string]TokenType{
-	"int": INT,
+	"int":    INT,
 	"return": RETURN,
 }
 


### PR DESCRIPTION
The initial framework has been implemented along with support for the
minus (-) operator used for negating values (i.e. -5, -foo).
