### PR TITLE
feat(eval): initial evaluator functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ recent version should work.
 ├── pkg
 │   ├── ast
 │   │   └── ast.go
+│   ├── evaluator
+│   │   ├── evaluator.go
+│   │   └── evaluator_test.go
 │   ├── lexer
 │   │   ├── lexer.go
 │   │   └── lexer_test.go
+│   ├── object
+│   │   └── object.go
 │   ├── parser
 │   │   ├── parser.go
 │   │   └── parser_test.go

--- a/cmd/corrosion/corrosion.go
+++ b/cmd/corrosion/corrosion.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/freddiehaddad/corrosion/pkg/ast"
+	"github.com/freddiehaddad/corrosion/pkg/evaluator"
 	"github.com/freddiehaddad/corrosion/pkg/lexer"
 	"github.com/freddiehaddad/corrosion/pkg/parser"
 )
@@ -14,8 +15,9 @@ const appName = "Corrosion"
 const prompt = "> "
 
 func evaluate(p *ast.Program) {
-	for index, statement := range p.Statements {
-		fmt.Printf("Statements[%d]: %s\n", index, statement.String())
+	for _, statement := range p.Statements {
+		obj := evaluator.Eval(statement)
+		fmt.Println(obj.Inspect())
 	}
 }
 

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -78,10 +78,10 @@ func (es *ExpressionStatement) TokenLiteral() string { return es.Token.Literal }
 func (es *ExpressionStatement) String() string       { return es.Expression.String() }
 
 type InfixExpression struct {
-	Token    token.Token // Prefix operator (e.g. - !)
 	Left     Expression
-	Operator string
 	Right    Expression
+	Token    token.Token
+	Operator string
 }
 
 func (i *InfixExpression) expressionNode()      {}
@@ -99,9 +99,9 @@ func (i *InfixExpression) String() string {
 }
 
 type PrefixExpression struct {
-	Token    token.Token // Prefix operator (e.g. - !)
-	Operator string
 	Right    Expression
+	Token    token.Token
+	Operator string
 }
 
 func (p *PrefixExpression) expressionNode()      {}

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -1,0 +1,91 @@
+package evaluator
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/freddiehaddad/corrosion/pkg/ast"
+	"github.com/freddiehaddad/corrosion/pkg/object"
+)
+
+var (
+	NULL = &object.Null{}
+)
+
+func Eval(node ast.Node) object.Object {
+	switch node := node.(type) {
+	case *ast.Program:
+		return evalStatements(node.Statements)
+	case *ast.ExpressionStatement:
+		return Eval(node.Expression)
+	case *ast.PrefixExpression:
+		return evalPrefixExpression(node)
+	case *ast.InfixExpression:
+		return evalInfixExpression(node)
+	case *ast.IntegerLiteral:
+		return evalIntegerLiteral(node)
+	default:
+		return NULL
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Evaluators
+// ----------------------------------------------------------------------------
+
+func evalInfixExpression(ie *ast.InfixExpression) object.Object {
+	result := &object.Integer{}
+
+	left := Eval(ie.Left)
+	right := Eval(ie.Right)
+
+	lValue, _ := strconv.ParseInt(left.Inspect(), 10, 64)
+	rValue, _ := strconv.ParseInt(right.Inspect(), 10, 64)
+
+	var value string
+
+	switch ie.Operator {
+	case "+":
+		v := lValue + rValue
+		value = fmt.Sprintf("%d", v)
+	case "-":
+		v := lValue - rValue
+		value = fmt.Sprintf("%d", v)
+	default:
+		return NULL
+	}
+
+	result.Value = value
+
+	return result
+}
+
+func evalPrefixExpression(pe *ast.PrefixExpression) object.Object {
+	result := Eval(pe.Right)
+
+	switch result.(type) {
+	case *object.Integer:
+		if pe.Operator == "-" {
+			s := fmt.Sprintf("%s%s", pe.Operator, result.Inspect())
+			v, _ := strconv.ParseInt(s, 10, 64)
+			s = fmt.Sprintf("%d", v)
+			return &object.Integer{Value: s}
+		}
+	}
+
+	return NULL
+}
+
+func evalIntegerLiteral(i *ast.IntegerLiteral) object.Object {
+	return &object.Integer{Value: i.Value}
+}
+
+func evalStatements(statements []ast.Statement) object.Object {
+	var result object.Object
+
+	for _, statement := range statements {
+		result = Eval(statement)
+	}
+
+	return result
+}

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1,0 +1,45 @@
+package evaluator
+
+import (
+	"testing"
+
+	"github.com/freddiehaddad/corrosion/pkg/lexer"
+	"github.com/freddiehaddad/corrosion/pkg/object"
+	"github.com/freddiehaddad/corrosion/pkg/parser"
+)
+
+func TestEvalIntegerExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"5", "5"},
+		{"10", "10"},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		testIntegerObject(t, evaluated, tt.expected)
+	}
+}
+
+func testEval(input string) object.Object {
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	return Eval(program)
+}
+
+func testIntegerObject(t *testing.T, obj object.Object, expected string) bool {
+	result, ok := obj.(*object.Integer)
+	if !ok {
+		t.Errorf("object is not Integer. got=%T (%+v)", obj, obj)
+		return false
+	}
+	if result.Value != expected {
+		t.Errorf("object has wrong value. got=%s, expected=%s", result.Value, expected)
+		return false
+	}
+
+	return true
+}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -52,8 +52,6 @@ func (l *Lexer) generateTokens() {
 		// operators
 		case '=':
 			tok = newTokenByte(token.ASSIGN, l.ch)
-		case '!':
-			tok = newTokenByte(token.BANG, l.ch)
 		case '-':
 			tok = newTokenByte(token.MINUS, l.ch)
 		case '+':

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -1,0 +1,27 @@
+package object
+
+type ObjectType string
+
+type Object interface {
+	Type() ObjectType
+	Inspect() string
+}
+
+const (
+	INTEGER_OBJ = "INTEGER"
+	NULL_OBJ    = "NULL"
+)
+
+type Null struct {
+	Value string
+}
+
+func (n *Null) Inspect() string  { return n.Value }
+func (n *Null) Type() ObjectType { return NULL_OBJ }
+
+type Integer struct {
+	Value string
+}
+
+func (i *Integer) Inspect() string  { return i.Value }
+func (i *Integer) Type() ObjectType { return INTEGER_OBJ }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -74,7 +74,6 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
 
 	p.prefixParseFns = make(map[token.TokenType]prefixParseFn)
-	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
 	p.registerPrefix(token.INTEGER, p.parseInteger)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -91,9 +91,9 @@ func checkPrefixExpression(t *testing.T, test int, expected []string, node *ast.
 			test, expected[0], node.Operator)
 	}
 
-	if node.Right.String() != expected[1] {
+	if node.String() != expected[1] {
 		t.Errorf("tests[%d]: incorrect Expression. expected=%q got=%q\n",
-			test, expected[1], node.Right.String())
+			test, expected[1], node.String())
 	}
 }
 
@@ -252,11 +252,11 @@ func TestInfixOperatorExpressions(t *testing.T) {
 func TestPrefixOperatorExpressions(t *testing.T) {
 	input := `
 		-10;
-		!5;
+		--5;
 		`
 	expected := testResults{
-		{"-", "10"},
-		{"!", "5"},
+		{"-", "(-10)"},
+		{"-", "(-(-5))"},
 	}
 
 	l := lexer.New(input)

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -16,7 +16,6 @@ const (
 
 	// operators
 	ASSIGN = "="
-	BANG   = "!"
 	MINUS  = "-"
 	PLUS   = "+"
 


### PR DESCRIPTION
Support for the evaluation step of the REPL is in place. Arithmetic
expressions can now be evaluated for the supported operators (- and +).
