### PR TITLE
fix(eval): handle case of undefined variables

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -137,8 +137,12 @@ func evalIntegerLiteral(
 }
 
 func evalIdentifier(i *ast.Identifier, env *object.Environment) object.Object {
-	obj, _ := env.Get(i.Value)
+	if obj, ok := env.Get(i.Value); ok {
 	return obj
+	}
+
+	e := fmt.Sprintf("ERROR: undefined identifier=%q (%+v)", i.Value, i)
+	return evalError(e)
 }
 
 func evalDeclarationStatement(

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -104,6 +104,36 @@ func TestArithmeticExpressions(t *testing.T) {
 	}
 }
 
+func TestArithmeticExpressionsWithVariables(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"3+x;", "ERROR: undefined identifier=\"x\" (x)"},
+		{"x+3;", "ERROR: undefined identifier=\"x\" (x)"},
+		{"int x = 3; x+y;", "ERROR: undefined identifier=\"y\" (y)"},
+		{"int y = 3; x+y;", "ERROR: undefined identifier=\"x\" (x)"},
+	}
+
+	for _, test := range tests {
+		e := object.NewEnvironment()
+
+		l := lexer.New(test.input)
+		p := parser.New(l)
+		program := p.ParseProgram()
+
+		result := Eval(program, e)
+
+		switch obj := result.(type) {
+		case *object.Error:
+			testErrorObject(t, obj, test.expected)
+		default:
+			t.Errorf("object is not Error. got=%T (%+v)",
+				obj, obj)
+		}
+	}
+}
+
 func TestDivideByZeroError(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
When an expression evaluates to an identifier that has not been
declared, an error should be returned.
