### PR TITLE
feat: type convert literals during parsing

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -140,12 +140,12 @@ func (rs *ReturnStatement) String() string {
 
 type Boolean struct {
 	Token token.Token
-	Value string
+	Value bool
 }
 
 func (b *Boolean) expressionNode()      {}
 func (b *Boolean) TokenLiteral() string { return b.Token.Literal }
-func (b *Boolean) String() string       { return b.Value }
+func (b *Boolean) String() string       { return b.Token.Literal }
 
 type Identifier struct {
 	Token token.Token
@@ -158,9 +158,9 @@ func (i *Identifier) String() string       { return i.Value }
 
 type IntegerLiteral struct {
 	Token token.Token
-	Value string
+	Value int64
 }
 
 func (i *IntegerLiteral) expressionNode()      {}
 func (i *IntegerLiteral) TokenLiteral() string { return i.Token.Literal }
-func (i *IntegerLiteral) String() string       { return i.Value }
+func (i *IntegerLiteral) String() string       { return i.Token.Literal }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -11,12 +11,12 @@ import (
 func TestEvalIntegerExpressions(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected string
+		expected int64
 	}{
-		{"5;", "5"},
-		{"10;", "10"},
-		{"-10;", "-10"},
-		{"--10;", "10"},
+		{"5;", 5},
+		{"10;", 10},
+		{"-10;", -10},
+		{"--10;", 10},
 	}
 
 	e := object.NewEnvironment()
@@ -41,12 +41,12 @@ func TestEvalIntegerExpressions(t *testing.T) {
 func TestEvalNotExpressions(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected string
+		expected bool
 	}{
-		{"!true;", "false"},
-		{"!false;", "true"},
-		{"!!true;", "true"},
-		{"!!false;", "false"},
+		{"!true;", false},
+		{"!false;", true},
+		{"!!true;", true},
+		{"!!false;", false},
 	}
 
 	e := object.NewEnvironment()
@@ -71,10 +71,10 @@ func TestEvalNotExpressions(t *testing.T) {
 func TestEvalBooleanExpressions(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected string
+		expected bool
 	}{
-		{"true;", "true"},
-		{"false;", "false"},
+		{"true;", true},
+		{"false;", false},
 	}
 
 	e := object.NewEnvironment()
@@ -99,48 +99,48 @@ func TestEvalBooleanExpressions(t *testing.T) {
 func TestArithmeticExpressions(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected string
+		expected int64
 	}{
-		{" 1 +  8;", "9"},
-		{"-2 +  6;", "4"},
-		{" 3 + -6;", "-3"},
-		{"-4 + -5;", "-9"},
+		{" 1 +  8;", 9},
+		{"-2 +  6;", 4},
+		{" 3 + -6;", -3},
+		{"-4 + -5;", -9},
 
-		{" 5 -  4;", "1"},
-		{"-6 -  3;", "-9"},
-		{" 7 - -2;", "9"},
-		{"-8 - -1;", "-7"},
+		{" 5 -  4;", 1},
+		{"-6 -  3;", -9},
+		{" 7 - -2;", 9},
+		{"-8 - -1;", -7},
 
-		{" 5 *  4;", "20"},
-		{"-6 *  3;", "-18"},
-		{" 7 * -2;", "-14"},
-		{"-8 * -1;", "8"},
+		{" 5 *  4;", 20},
+		{"-6 *  3;", -18},
+		{" 7 * -2;", -14},
+		{"-8 * -1;", 8},
 
-		{" 5 /  4;", "1"},
-		{"-6 /  3;", "-2"},
-		{" 7 / -2;", "-3"},
-		{"-8 / -1;", "8"},
+		{" 5 /  4;", 1},
+		{"-6 /  3;", -2},
+		{" 7 / -2;", -3},
+		{"-8 / -1;", 8},
 
-		{" 5 * 10 + 15;", "65"},
-		{" 5 * 10 - 15;", "35"},
-		{" 5 * 10 + -15;", "35"},
-		{" 5 * 10 - -15;", "65"},
+		{" 5 * 10 + 15;", 65},
+		{" 5 * 10 - 15;", 35},
+		{" 5 * 10 + -15;", 35},
+		{" 5 * 10 - -15;", 65},
 
-		{" -5 * 10 + 15;", "-35"},
-		{" -5 * 10 - 15;", "-65"},
-		{" -5 * 10 + -15;", "-65"},
-		{" -5 * 10 - -15;", "-35"},
+		{" -5 * 10 + 15;", -35},
+		{" -5 * 10 - 15;", -65},
+		{" -5 * 10 + -15;", -65},
+		{" -5 * 10 - -15;", -35},
 
-		{" 5 * -10 + 15;", "-35"},
-		{" 5 * -10 - 15;", "-65"},
-		{" 5 * -10 + -15;", "-65"},
-		{" 5 * -10 - -15;", "-35"},
+		{" 5 * -10 + 15;", -35},
+		{" 5 * -10 - 15;", -65},
+		{" 5 * -10 + -15;", -65},
+		{" 5 * -10 - -15;", -35},
 
-		{" -5 * -10 - 15;", "35"},
-		{" -5 * -10 + -15;", "35"},
+		{" -5 * -10 - 15;", 35},
+		{" -5 * -10 + -15;", 35},
 
-		{" 10 / 2 * 7;", "35"},
-		{" 10 * 2 / 4;", "5"},
+		{" 10 / 2 * 7;", 35},
+		{" 10 * 2 / 4;", 5},
 	}
 
 	e := object.NewEnvironment()
@@ -197,10 +197,10 @@ func TestDivideByZeroError(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"0 / 0;", "ERROR: divide by zero error in expression ((0 / 0))"},
-		{"1 / 0;", "ERROR: divide by zero error in expression ((1 / 0))"},
-		{"1 + 2 / 0;", "ERROR: divide by zero error in expression ((2 / 0))"},
-		{"1 / 0 + 2;", "ERROR: divide by zero error in expression ((1 / 0))"},
+		{"0 / 0;", "ERROR: divide by zero error in expression (0 / 0)"},
+		{"1 / 0;", "ERROR: divide by zero error in expression (1 / 0)"},
+		{"1 + 2 / 0;", "ERROR: divide by zero error in expression (2 / 0)"},
+		{"1 / 0 + 2;", "ERROR: divide by zero error in expression (1 / 0)"},
 	}
 
 	e := object.NewEnvironment()
@@ -225,14 +225,14 @@ func TestDivideByZeroError(t *testing.T) {
 func TestVariableDeclaration(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected string
+		expected int64
 	}{
-		{"int x = 3; x;", "3"},
-		{"int y = 2; y;", "2"},
-		{"x + y;", "5"},
-		{"y + x;", "5"},
-		{"x - y;", "1"},
-		{"y - x;", "-1"},
+		{"int x = 3; x;", 3},
+		{"int y = 2; y;", 2},
+		{"x + y;", 5},
+		{"y + x;", 5},
+		{"x - y;", 1},
+		{"y - x;", -1},
 	}
 
 	e := object.NewEnvironment()
@@ -254,16 +254,16 @@ func TestVariableDeclaration(t *testing.T) {
 	}
 }
 
-func testBooleanObject(t *testing.T, obj *object.Boolean, expected string) {
+func testBooleanObject(t *testing.T, obj *object.Boolean, expected bool) {
 	if obj.Value != expected {
-		t.Errorf("object has wrong value. got=%s, expected=%s",
+		t.Errorf("object has wrong value. got=%t, expected=%t",
 			obj.Value, expected)
 	}
 }
 
-func testIntegerObject(t *testing.T, obj *object.Integer, expected string) {
+func testIntegerObject(t *testing.T, obj *object.Integer, expected int64) {
 	if obj.Value != expected {
-		t.Errorf("object has wrong value. got=%s, expected=%s",
+		t.Errorf("object has wrong value. got=%d, expected=%d",
 			obj.Value, expected)
 	}
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -1,5 +1,7 @@
 package object
 
+import "fmt"
+
 type ObjectType string
 
 type Object interface {
@@ -15,17 +17,17 @@ const (
 )
 
 type Boolean struct {
-	Value string
+	Value bool
 }
 
-func (b *Boolean) Inspect() string  { return b.Value }
+func (b *Boolean) Inspect() string  { return fmt.Sprintf("%t", b.Value) }
 func (b *Boolean) Type() ObjectType { return BOOLEAN_OBJ }
 
 type Integer struct {
-	Value string
+	Value int64
 }
 
-func (i *Integer) Inspect() string  { return i.Value }
+func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
 func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
 
 type Error struct {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/freddiehaddad/corrosion/pkg/ast"
 	"github.com/freddiehaddad/corrosion/pkg/lexer"
@@ -260,7 +261,7 @@ func (p *Parser) parsePrefixExpression() ast.Expression {
 func (p *Parser) parseBoolean() ast.Expression {
 	return &ast.Boolean{
 		Token: p.currentToken,
-		Value: p.currentToken.Literal,
+		Value: p.currentTokenIs(token.TRUE),
 	}
 }
 
@@ -272,9 +273,15 @@ func (p *Parser) parseIdentifier() ast.Expression {
 }
 
 func (p *Parser) parseInteger() ast.Expression {
+	value, err := strconv.ParseInt(p.currentToken.Literal, 0, 64)
+	if err != nil {
+		p.error(err.Error())
+		return nil
+	}
+
 	return &ast.IntegerLiteral{
 		Token: p.currentToken,
-		Value: p.currentToken.Literal,
+		Value: value,
 	}
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/freddiehaddad/corrosion/pkg/ast"
@@ -58,9 +59,20 @@ func checkStatements(t *testing.T, expects testResults, stmts []ast.Statement) {
 func checkBoolean(
 	t *testing.T, test int, expected []string, node *ast.Boolean,
 ) {
-	if node.Value != expected[0] {
+	if node.Token.Literal != expected[0] {
 		t.Errorf("tests[%d]: incorrect value. expected=%q got=%q\n",
-			test, expected[0], node.Value)
+			test, expected[0], node.Token.Literal)
+	}
+
+	value, err := strconv.ParseBool(expected[0])
+	if err != nil {
+		t.Errorf("tests[%d]: failed to parse expected[0]=%s: err=%s",
+			test, expected[0], err.Error())
+	}
+
+	if node.Value != value {
+		t.Errorf("tests[%d]: incorrect value. expected=%t got=%t\n",
+			test, value, node.Value)
 	}
 }
 
@@ -76,9 +88,20 @@ func checkIdentifier(
 func checkIntegerLiteral(
 	t *testing.T, test int, expected []string, node *ast.IntegerLiteral,
 ) {
-	if node.Value != expected[0] {
+	if node.Token.Literal != expected[0] {
 		t.Errorf("tests[%d]: incorrect value. expected=%q got=%q\n",
 			test, expected[0], node.Value)
+	}
+
+	value, err := strconv.ParseInt(expected[0], 0, 64)
+	if err != nil {
+		t.Errorf("tests[%d]: failed to parse expected[0]=%s: err=%s",
+			test, expected[0], err.Error())
+	}
+
+	if node.Value != value {
+		t.Errorf("tests[%d]: incorrect value. expected=%d got=%d\n",
+			test, value, node.Value)
 	}
 }
 


### PR DESCRIPTION
For integers and booleans, rather than waiting until the evaluation
phase to detect type conversion errors, we can catch them during the
parsing phase.  The integer and boolean AST nodes now store their values
as bool or int64, respectively.
