### PR TITLE
fix: make assignments right associative

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -69,23 +69,6 @@ func (ds *DeclarationStatement) String() string {
 	return sb.String()
 }
 
-type AssignmentStatement struct {
-	Value Expression
-	Name  Identifier
-	Token token.Token
-}
-
-func (as *AssignmentStatement) statementNode() {}
-func (as *AssignmentStatement) TokenLiteral() string { return as.Token.Literal }
-func (as *AssignmentStatement) String() string {
-	var sb strings.Builder
-	sb.WriteString(as.Name.String())
-	sb.WriteString(" = ")
-	sb.WriteString(as.Value.String())
-	sb.WriteString(";")
-	return sb.String()
-}
-
 type ExpressionStatement struct {
 	Expression Expression
 	Token      token.Token
@@ -96,6 +79,27 @@ func (es *ExpressionStatement) TokenLiteral() string {
 	return es.Token.Literal
 }
 func (es *ExpressionStatement) String() string { return es.Expression.String() }
+
+type AssignmentExpression struct {
+	Token    token.Token
+	Left     Expression
+	Right    Expression
+	Operator string
+}
+
+func (a *AssignmentExpression) expressionNode()      {}
+func (a *AssignmentExpression) TokenLiteral() string { return a.Token.Literal }
+func (a *AssignmentExpression) String() string {
+	sb := strings.Builder{}
+	sb.WriteByte('(')
+	sb.WriteString(a.Left.String())
+	sb.WriteByte(' ')
+	sb.WriteString(a.Operator)
+	sb.WriteByte(' ')
+	sb.WriteString(a.Right.String())
+	sb.WriteByte(')')
+	return sb.String()
+}
 
 type InfixExpression struct {
 	Left     Expression

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -394,7 +394,7 @@ func TestVariableDeclaration(t *testing.T) {
 	}
 }
 
-func TestAssignmentStatement(t *testing.T) {
+func TestAssignment(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected int64

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -283,13 +283,15 @@ func TestBooleanExpressions(t *testing.T) {
 	checkStatements(t, expected, program.Statements)
 }
 
-func TestAssignmentStatement(t *testing.T) {
+func TestAssignment(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
 	}{
-		{"x = 2;", "x = 2;"},
-		{"foo = 2 * y;", "foo = (2 * y);"},
+		{"x = 2;", "(x = 2)"},
+		{"foo = 2 * y;", "(foo = (2 * y))"},
+		{"foo = bar = baz = 100;", "(foo = (bar = (baz = 100)))"},
+		{"foo = bar = baz = x + 3;", "(foo = (bar = (baz = (x + 3))))"},
 	}
 
 	for index, test := range tests {


### PR DESCRIPTION
This allows expressions such as x = y = z = 3;
